### PR TITLE
implement vctrs vec_proxy() and vec_restore()

### DIFF
--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -828,6 +828,8 @@
 
     register_S3_method("vctrs", "vec_ptype_abbr", "declared")
     register_S3_method("vctrs", "vec_ptype_full", "declared")
+    register_S3_method("vctrs", "vec_proxy", "declared")
+    register_S3_method("vctrs", "vec_restore", "declared")
     # register_S3_method("vctrs", "vec_ptype2", "declared")
 
     register_S3_method("vroom", "output_column", "declared")

--- a/R/vctrs.R
+++ b/R/vctrs.R
@@ -3,6 +3,43 @@
 # labelled and pillar  these functions will be registered when or if the package
 # vctrs is loaded
 
+`vec_proxy.declared` <- function (x, ...) {
+    return (undeclare(x, drop=TRUE))
+}
+
+`vec_restore.declared` <- function(x, to, ...) {
+    new_attrs <- attributes(to)
+
+    misvals <- all_missing_values (
+        x,
+        new_attrs$na_values,
+        new_attrs$na_range,
+        new_attrs$labels
+    )
+
+    na_index <- which(is.element(x, misvals))
+
+    if (length(na_index) > 0) {
+      declared_nas <- x[na_index]
+
+      if (new_attrs$date) {
+        declared_nas <- as.numeric (declared_nas)
+      }
+
+      x[na_index] <- NA
+      names(na_index) <- declared_nas
+    }
+    else {
+      na_index <- NULL
+    }
+
+    new_attrs$na_index <- na_index
+
+    attributes(x) <- new_attrs
+
+    return (x)
+}
+
 `vec_ptype_abbr.declared` <- function (x, ...) {
     command <- "vctrs::vec_ptype_abbr(vctrs::vec_data(unclass (undeclare (x))))"
     return (


### PR DESCRIPTION
Hi again, I think I've figured out a simple fix for #7! It's just a proof-of-concept (I haven't made tests for it yet), but it looks like a really promising approach.

All I've done is implement [`vctrs::vec_proxy()` and `vctrs::vec_restore()`](https://vctrs.r-lib.org/reference/vec_proxy.html) for declared classes, using the similar dynamic-loading S3 approach you're already taking with a few other vctrs functions.

With these small additions, `dplyr::count()` and `dplyr::group_by()` now have their expected behaviors in all the situations I mentioned in #7:

```r
df <- tibble(
    x = declared(c(1,2,"a", "b", "a", 1, 2, "b", "b"), na_values=c("a", "b")),
    y = 1:9,
)
df |> count(x)
#> # A tibble: 3 × 2
#>   x             n
#>   <chr+lbl> <int>
#> 1     1         2
#> 2     2         2
#> 3 NA(a)         2
#> 4 NA(b)         3
```

```r
df |> group_by(x) |> summarize(n = n())
#> # A tibble: 3 × 2
#>   x             n
#>   <chr+lbl> <int>
#> 1     1         2
#> 2     2         2
#> 3 NA(a)         2
#> 4 NA(b)         3
```

```r
df |>
  group_by(x) |>
  summarize(y_mean = mean(y), n = n()) |>
  filter(is.na(x))
#> # A tibble: 2 × 3
#>   x         y_mean     n
#>   <chr+lbl>  <dbl> <int>
#> 1 NA(a)        4       2
#> 2 NA(b)        7       3
```

```r
df |>
  group_by(x) |>
  mutate(y_mean = mean(y), n = n())
#> # A tibble: 9 × 4
#> # Groups:   x [4]
#>   x             y y_mean     n
#>   <chr+lbl> <int>  <dbl> <int>
#> 1     1         1    3.5     2
#> 2     2         2    4.5     2
#> 3 NA(a)         3    4       2
#> 4 NA(b)         4    7       3
#> 5 NA(a)         5    4       2
#> 6     1         6    3.5     2
#> 7     2         7    4.5     2
#> 8 NA(b)         8    7       3
#> 9 NA(b)         9    7       3
```

Anyway, let me know if this is an addition you'd consider for declared, and if so, I'd be happy to start adding unit tests and checking other potential edge cases...